### PR TITLE
Fixed a bug where a deleted volunteer couldn't register again.

### DIFF
--- a/cleansweep/models.py
+++ b/cleansweep/models.py
@@ -506,11 +506,9 @@ class PendingMember(db.Model):
 
     def reject(self):
         self.status = 'rejected'
-        db.session.add(self)
 
     def approve(self):
         self.status = 'approved'
-        db.session.add(self)
         return self.place.add_member(self.name, self.email, self.phone, self.voterid)
 
 class Contact(db.Model):

--- a/cleansweep/signups/templates/signup.html
+++ b/cleansweep/signups/templates/signup.html
@@ -6,9 +6,15 @@
 
 {% block content_body %}
   {% if pending_member %}
-      <div class="well">
-        You have already applied as volunteer. You'll hear from us shortly.
-      </div>
+    {% if pending_member.status == 'pending' %}
+        <div class="alert alert-warning">
+            You have already applied as volunteer. You'll hear from us shortly.
+        </div>
+    {% elif pending_member.status == 'rejected' %}
+        <div class="alert alert-danger">
+            Your request to sign up as volunteer has been rejected. Please contact administrator.
+        </div>
+     {% endif %}
   {% elif userdata %}
     <div class="row">
       <div class="col-md-4">
@@ -55,7 +61,7 @@
   {% else %}
     <p>Please authenticate yourself using the following services to continue with the sign up process.</p>
     <p>
-      {% for provider in get_oauth_providers() %}      
+      {% for provider in get_oauth_providers() %}
         <a href="{{ url_for('oauth_redirect', view='signups.signup', provider=provider.name) }}" class="btn btn-primary">{{provider.title}}</a>
       {% endfor %}
     </p>

--- a/cleansweep/signups/views.py
+++ b/cleansweep/signups/views.py
@@ -27,11 +27,10 @@ def signup():
             session['user'] = user.email
             return redirect(url_for("dashboard"))
 
-        # is already a member?
+        # is a pending member?
         pending_member = PendingMember.find(email=userdata['email'])
-        if pending_member:
+        if pending_member and not pending_member.status == 'approved':
             return render_template("signup.html", userdata=None, pending_member=pending_member)
-
     # show the form
     form = forms.SignupForm()
     if request.method == "GET":

--- a/cleansweep/volunteers/views.py
+++ b/cleansweep/volunteers/views.py
@@ -75,6 +75,8 @@ def profile(id, hash):
     if request.method == "POST":
         action = request.form.get('action')
         if action == 'delete':
+            from ..models import PendingMember
+            pending_member = PendingMember.find(email=m.email)
             place = m.place
             # TODO: Make sure the member is not part of any committee
 
@@ -84,6 +86,7 @@ def profile(id, hash):
             from ..audit.models import Audit
             Audit.query.filter_by(person_id=m.id).delete()
             Audit.query.filter_by(user_id=m.id).delete()
+            db.session.delete(pending_member)
             db.session.delete(m)
             db.session.commit()
             signals.delete_volunteer.send(m, place=place)


### PR DESCRIPTION
This is mentioned in #100 

When a user registers we store a `PendingMember` object.
After approving, instead of deleting `PendingMember` we change its `status` variable to 'approved'.

This creates problem if a volunteer who was removed tries to register again. Because volunteer's `PendingMember` object is still there in the database, system doesn't let him/her go through and displays the message 'you've already applied for volunteering'.

A quick fix is to also delete `PendingMember` when deleting volunteer.