### PR TITLE
Selecting multiple permissions for a committee role

### DIFF
--- a/cleansweep/committees/models.py
+++ b/cleansweep/committees/models.py
@@ -121,10 +121,8 @@ class CommitteeType(db.Model):
         db.session.add(c)
         for roledata in form.data['roles']:
             if roledata.get('name') and roledata['name'].strip():
-                c.add_role(
-                    roledata['name'],
-                    roledata['multiple'] == 'yes',
-                    roledata['permission'])
+                permissions = ",".join(roledata['permission'])  # comma separated permissions in a string
+                c.add_role(roledata['name'], roledata['multiple'] == 'yes', permissions)
         return c
 
     def url_for(self, endpoint):

--- a/cleansweep/committees/templates/edit_committee_structure.html
+++ b/cleansweep/committees/templates/edit_committee_structure.html
@@ -1,6 +1,11 @@
 {% from "macros.html" import render_field %}
 {% extends "place.html" %}
 
+{% block extrahead %}
+  <link rel="stylesheet" href="{{ url_for('static', filename="chosen/bootstrap-chosen.css") }}"/>
+  <script type="text/javascript" src="{{ url_for('static', filename="chosen/chosen.jquery.min.js") }}"></script>
+{% endblock %}
+
 {% block page_content %}
   <ul class="breadcrumb breadcrumb-collapse">
     <li><a href="{{url_for('.committee_structures', key=place.key)}}">Committee Structures</a></li>
@@ -8,15 +13,17 @@
   </ul>  
   <h2>Edit <a href="{{committee_type.url_for('.view_committee_structure')}}">{{committee_type.name}}</a></h2>
 
-<form role="form" method="POST" style="width: 400px">
-  {{ form.csrf_token }}
-  {{ form.committee_type_id() }}  
-  {{ render_field(form.name) }}
-  {{ render_field(form.slug) }}
-  {{ render_field(form.level, readonly="true") }}
-  {{ render_field(form.description) }}
+<form role="form" method="POST">
+  <div style="width: 400px">
+    {{ form.csrf_token }}
+    {{ form.committee_type_id() }}
+    {{ render_field(form.name) }}
+    {{ render_field(form.slug) }}
+    {{ render_field(form.level, readonly="true") }}
+    {{ render_field(form.description) }}
+  </div>
 
-  <h3>Roles</strong></h3>
+  <h3>Roles</h3>
   <table class="table table-borderless roles-table">
     <tr>
       <th>Role</th><th>#Members</th><th>Permissions</th>
@@ -25,9 +32,9 @@
       {% for role in form.roles %}
         <tr class="tr-role">
           {{ role.form.role_id() }}
-          <td>{{ role.form.name() }}</td>
-          <td>{{ role.form.multiple() }}</td>
-          <td>{{ role.form.permission() }}</td>
+          <td style="width: 30%">{{ role.form.name(class_="form-control") }}</td>
+          <td style="width: 30%">{{ role.form.multiple(class="form-control") }}</td>
+          <td style="width: 40%">{{ role.form.permission(class_="form-control permissions") }}</td>
         </tr>
       {% endfor %}
     </tbody>
@@ -40,6 +47,10 @@
 
 <script type="text/javascript">
   $(function() {
+    $(".permissions").chosen({
+        placeholder_text_multiple: "Select member permissions",
+        no_results_text: "No permissions found",
+    });
     function add_role() {
       var tr = $("#tbody-roles tr:last-child").clone();
       var count = $("#tbody-roles tr").length;

--- a/cleansweep/committees/templates/new_committee_structure.html
+++ b/cleansweep/committees/templates/new_committee_structure.html
@@ -1,15 +1,22 @@
 {% from "macros.html" import render_field %}
 {% extends "place.html" %}
 
+{% block extrahead %}
+  <link rel="stylesheet" href="{{ url_for('static', filename="chosen/bootstrap-chosen.css") }}"/>
+  <script type="text/javascript" src="{{ url_for('static', filename="chosen/chosen.jquery.min.js") }}"></script>
+{% endblock %}
+
 {% block page_content %}
   <h2>Add a new committee structure</h2>
 
-<form role="form" method="POST" style="width: 400px">
-  {{ form.csrf_token }}
-  {{ render_field(form.name) }}
-  {{ render_field(form.slug) }}
-  {{ render_field(form.level) }}
-  {{ render_field(form.description) }}
+<form role="form" method="POST">
+  <div style="width: 400px">
+    {{ form.csrf_token }}
+    {{ render_field(form.name) }}
+    {{ render_field(form.slug) }}
+    {{ render_field(form.level) }}
+    {{ render_field(form.description) }}
+  </div>
 
   <h3>Roles</h3>
   <table class="table table-borderless roles-table">
@@ -19,9 +26,9 @@
     <tbody id="tbody-roles">
       {% for role in form.roles %}
         <tr class="tr-role">
-          <td>{{ role.form.name }}</td>
-          <td>{{ role.form.multiple }}</td>
-          <td>{{ role.form.permission }}</td>
+          <td style="width: 30%">{{ role.form.name(class_="form-control") }}</td>
+          <td style="width: 30%">{{ role.form.multiple(class="form-control") }}</td>
+          <td style="width: 40%">{{ role.form.permission(class_="form-control permissions") }}</td>
         </tr>
       {% endfor %}
     </tbody>
@@ -34,6 +41,10 @@
 
 <script type="text/javascript">
   $(function() {
+    $(".permissions").chosen({
+        placeholder_text_multiple: "Select member permissions",
+        no_results_text: "No permissions found",
+    });
     function add_role() {
       var tr = $("#tbody-roles tr:last-child").clone();
       var count = $("#tbody-roles tr").length;

--- a/cleansweep/static/chosen/bootstrap-chosen.css
+++ b/cleansweep/static/chosen/bootstrap-chosen.css
@@ -245,7 +245,9 @@
   margin: 0 0 0 0;
   padding: 0; }
 .chosen-container-multi .chosen-drop .result-selected {
-  display: none; }
+  display: list-item;
+  color: #ccc;
+  cursor: default; }
 
 .chosen-container-active .chosen-single {
   border: 1px solid #66afe9;

--- a/requirements.txt
+++ b/requirements.txt
@@ -40,3 +40,4 @@ flask-paginate==0.3.2
 Flask-Migrate==1.5.1
 alembic==0.8.2
 -e git+git://github.com/anandology/mockdown.git#egg=mockdown
+WTForms-Components==0.9.8


### PR DESCRIPTION
This is for #127 

Using [chosen](http://harvesthq.github.io/chosen) for organized and user friendly selection boxes.
Also using [wtforms-component](http://wtforms-components.readthedocs.org/en/latest/) for [optgroup](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/optgroup) support in [wtforms](http://wtforms.readthedocs.org/en/latest/).

Storing permissions in a string separated by commas. To unpack in a list use `split`.
